### PR TITLE
docs: fill in instructions for missing commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,15 +3,16 @@
 WIP
 
 ## Setup
-1. Install the Garmin ConnectIQ SDK and follow its setup steps
+
+1. Install the Garmin ConnectIQ SDK and follow its [setup instructions](https://developer.garmin.com/connect-iq/connect-iq-basics/getting-started/#theconnectiqsdkmanager)
 2. Install Garmin's MonkeyC vscode extension
 3. Set up a dev key by running the `Monkey C: Verify Installation` command from your vscode command pallette (cmd-shift-p). NOTE: you must save this file to the repo root.
-4. Run `./dev.sh` from your console to start everything up!
+4. Make the `connectiq` and `monkeyc` shell commands available by following the [setup instructions](https://developer.garmin.com/connect-iq/reference-guides/monkey-c-command-line-setup/)
+5. Run `./dev.sh` from your console to start everything up!
 
 ## Development workflow
+
 1. run `./dev.sh`
 2. that's it! Your app will refresh in the sim after you make any change to the source files.
 
-
 https://github.com/walkerdb/garmagotchi/assets/7026330/5a737db7-2b82-4764-895a-13886b79b580
-


### PR DESCRIPTION
<img width="733" alt="Screenshot 2023-09-17 at 8 06 43 AM" src="https://github.com/walkerdb/garmagotchi/assets/1877652/32ec1c1b-45ad-4d07-be10-66827be2f5b0">

Ran into some errors because I didn't have the `monkeyc` cli setup, so added some instructions to fill in the missing commands before running `./dev.sh`.